### PR TITLE
allow strict access of public packages as well as private ones

### DIFF
--- a/templates/default/config.yaml.erb
+++ b/templates/default/config.yaml.erb
@@ -50,11 +50,11 @@ packages:
   <% end %>
 <% end %>
   '*':
-    <% if node['sinopia']['filters']['strict_access'] %>
-      allow_access: admin <%= @admins.join(' ') %>
-    <% else %>
-      allow_access: all
-    <% end %>
+  <% if node['sinopia']['filters']['strict_access'] %>
+    allow_access: admin <%= @admins.join(' ') %>
+  <% else %>
+    allow_access: all
+  <% end %>
     allow_publish: admin <%= @admins.join(' ') %>
     proxy: <%= node['sinopia']['mainrepo'] %>
 


### PR DESCRIPTION
- it would be great if there was an attribute called `strict_access` that would allow more control over public packages hosted on private sinopia servers as well. 
