### PR TITLE
Add centos init scripts

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,6 +13,8 @@ driver_config:
 platforms:
 - name: ubuntu-12.04
 - name: ubuntu-14.04
+- name: centos-6.5
+- name: centos-7.0
 
 provisioner:
     name: chef_zero

--- a/recipes/sinopia.rb
+++ b/recipes/sinopia.rb
@@ -47,12 +47,25 @@ logrotate_app 'sinopia' do
   create '644 root adm'
 end
 
-template '/etc/init/sinopia.conf' do
-  source 'sinopia.conf.erb'
+if node['platform_family'] == 'rhel'
+  service_provider = Chef::Provider::Service::Redhat
+
+  package 'redhat-lsb-core'
+
+  template '/etc/init.d/sinopia' do
+    source 'sinopia.sysvinit.erb'
+    mode '0755'
+  end
+else
+  service_provider = Chef::Provider::Service::Upstart
+
+  template '/etc/init/sinopia.conf' do
+    source 'sinopia.conf.erb'
+  end
 end
 
 service 'sinopia' do
-  provider Chef::Provider::Service::Upstart
+  provider service_provider
   supports :status => true, :restart => true, :reload => false
   action [:enable, :start]
 end

--- a/templates/default/sinopia.sysvinit.erb
+++ b/templates/default/sinopia.sysvinit.erb
@@ -1,0 +1,117 @@
+#! /bin/sh
+#
+# sinopia service script
+#
+# chkconfig: 345 70 45
+# description: Sinopia NPM cache & private repo server
+# processname: sinopia
+#
+
+### BEGIN INIT INFO
+# Provides: sinopia
+# Required-Start: $local_fs $remote_fs
+# Required-Stop: $local_fs $remote_fs
+# Default-Start: 2 3 4 5
+# Default-Stop: S 0 1 6
+# Short-Description: Sinopia NPM cache & private repo server
+# Description: Sinopia NPM cache & private repo server
+### END INIT INFO
+
+# Define LSB functions.
+if [ -f /lib/lsb/init-functions ]; then
+  . /lib/lsb/init-functions
+fi
+
+if [ -f /etc/init.d/functions ]; then
+  . /etc/init.d/functions
+fi
+
+NAME=sinopia
+PATH=/bin:/usr/bin:/sbin:/usr/sbin
+DAEMON=/usr/bin/${NAME}
+DIR=/var/run/sinopia
+PID=/var/run/sinopia/sinopia_server.pid
+LOCK=/var/lock/subsys/$NAME
+USER=<%= node['sinopia']['user'] %>
+GROUP=<%= node['sinopia']['user'] %>
+
+# Exit if the package is not installed
+if [ ! -x "$DAEMON" ]; then
+  echo "Couldn't find $DAEMON"
+  exit 99
+fi
+
+[ -d "$DIR" ] || mkdir "$DIR"
+chown -R $USER:$GROUP "$DIR"
+
+start()
+{
+  runuser -l "$USER" -c "$DAEMON -c <%= File.join(node['sinopia']['confdir'], 'config.yaml') %> &" && echo_success || echo_failure
+  RETVAL=$?
+  sleep 1
+  [ $RETVAL -eq 0 ] && touch $LOCK
+  ps -aefw | grep "$NAME" | grep -v " grep " | awk '{print $2}' > $PID
+  return $RETVAL
+}
+
+stop()
+{
+  killproc -p $PID
+  RETVAL="$?"
+  [ $RETVAL -eq 0 ] && rm -f $PID $LOCK
+  return "$RETVAL"
+}
+
+case "$1" in
+  start)
+    start
+    if [ "$?" -gt 0 ];
+    then
+      log_failure_msg "$NAME did not start"
+    else
+      log_success_msg "$NAME started"
+    fi
+    ;;
+  stop)
+    stop
+    if [ "$?" -gt 0 ];
+    then
+      log_failure_msg "$NAME did not stop"
+    else
+      log_success_msg "$NAME stopped"
+    fi
+    ;;
+  restart)
+    stop
+    if [ "$?" -gt 0 ];
+    then
+      log_failure_msg "$NAME did not stop"
+    else
+      sleep 5
+      start
+      if [ "$?" -gt 0 ];
+      then
+        log_failure_msg "$NAME did not start"
+      else
+        log_success_msg "$NAME restarted"
+      fi
+    fi
+    ;;
+  status)
+    PID_NUM=$(pidofproc -p $PID)
+    if [ "$?" -gt 0 ];
+    then
+      log_failure_msg "$NAME is not running"
+      exit 1
+    else
+      log_success_msg "$NAME is running ($PID_NUM)"
+      exit 0
+    fi
+    ;;
+  *)
+    echo "Usage: $NAME {start|stop|restart|status}" >&2
+    exit 3
+    ;;
+esac
+
+exit 0

--- a/test/integration/default/bats/sinopia.bats
+++ b/test/integration/default/bats/sinopia.bats
@@ -13,5 +13,5 @@
 }
 
 @test "sinopia should be listening TCP 4873" {
-    [ "$(netstat -plant |grep node |grep 4873)" ]
+    [ "$(netstat -plant | grep 4873 | grep LISTEN)" ]
 }


### PR DESCRIPTION
Fixes #6

This works in my CentOS6 environment. I added CentOS7 to test kitchen and it works there.

Also clean up the test as the new version of sinopia seems not to use
the path in the processlist.

