### PR TITLE
Access control fixes in config template

### DIFF
--- a/templates/default/config.yaml.erb
+++ b/templates/default/config.yaml.erb
@@ -49,6 +49,9 @@ packages:
   <% if filter['storage'] %>
     storage: <%= filter['storage'] %>
   <% end %>
+  <% if filter['proxy'] %>
+    proxy: <%= filter['proxy'] %>
+  <% end %>
   <%- wildcard_is_defined ||= (filter['name'] == '*') -%>
 <% end %>
 <%- if !wildcard_is_defined -%>

--- a/templates/default/config.yaml.erb
+++ b/templates/default/config.yaml.erb
@@ -25,6 +25,7 @@ maxage: <%= node['sinopia']['maxage'] %>
 <% end %>
 
 packages:
+<%- wildcard_is_defined = false -%>
 <% node['sinopia']['filters'].each do |filter| %>
   '<%= filter['name'] %>':
   <% if filter['access'] %>
@@ -34,7 +35,7 @@ packages:
     allow_access: admin <%= filter['access'].join(' ') %>
     <% end %>
   <% else %>
-    allow_access: all
+    allow_access: $all
   <% end %>
   <% if filter['publish'] %>
     <% if filter['publish'] == '@admins' %>
@@ -48,15 +49,18 @@ packages:
   <% if filter['storage'] %>
     storage: <%= filter['storage'] %>
   <% end %>
+  <%- wildcard_is_defined ||= (filter['name'] == '*') -%>
 <% end %>
+<%- if !wildcard_is_defined -%>
   '*':
   <% if node['sinopia']['strict_access'] %>
     allow_access: admin <%= @admins.join(' ') %>
   <% else %>
-    allow_access: all
+    allow_access: $all
   <% end %>
     allow_publish: admin <%= @admins.join(' ') %>
     proxy: <%= node['sinopia']['mainrepo'] %>
+<%- end -%>
 
 #####################################################################
 # Advanced settings


### PR DESCRIPTION
 - To allow access to all users, use `$all`.
 - If the user has defined settings for the `'*'` filter, don't override them.
 - Add the ability to define the `proxy` option for a package filter.